### PR TITLE
Only get first author from Libby

### DIFF
--- a/src/__tests__/providers/libby.test.ts
+++ b/src/__tests__/providers/libby.test.ts
@@ -93,7 +93,6 @@ describe("getLibby", () => {
       {
         "authors": [
           "Costanza Casati",
-          "Olivia Vinall",
         ],
         "categories": [
           "Fiction",

--- a/src/providers/libby.ts
+++ b/src/providers/libby.ts
@@ -71,14 +71,23 @@ function parseResult(result: OgObject): {
   return {
     title: result.ogTitle,
     description: formatDescription(result.ogDescription),
-    authors: Array.isArray(result.customMetaTags?.authors)
-      ? result.customMetaTags?.authors
-      : result.bookAuthor
-        ? [result.bookAuthor]
-        : [],
+    authors: formatAuthor(result),
     publishedDate: result.bookReleaseDate,
     thumbnail: result?.ogImage?.[0]?.url ?? "",
   };
+}
+
+function formatAuthor(result: OgObject): string[] {
+  if (Array.isArray(result.customMetaTags?.authors)) {
+    // Only get the first one as Libby includes narrator in this list
+    return [result.customMetaTags.authors[0]];
+  }
+
+  if (result.bookAuthor) {
+    return [result.bookAuthor];
+  }
+
+  return [];
 }
 
 function handleFormat(shareCategory: string): string | undefined {


### PR DESCRIPTION
Libby appends the narrator as an author. This PR introduces a workaround that will only get the first author. Unfortunately, this might mean we don't get multiple authors for a given book (it's also possible to have multiple narrators, so it's hard to slice accurately).

Fixes #174 