### PR TITLE
Introduce reader-defined duration

### DIFF
--- a/.github/workflows/read.yml
+++ b/.github/workflows/read.yml
@@ -51,6 +51,14 @@ on:
       tags:
         description: Add tags to categorize the book. Separate each tag with a comma.
         type: string
+      # Duration is optional
+      # It must be in ISO 8601 format
+      # Example:
+      # PT8H30M0S
+      # is 8 hours, 30 minutes, and 0 seconds
+      duration:
+        description: Duration of the Libby audiobook in ISO 8601 format (PT##H##M##S).
+        type: string
 
 # Set up the steps to run the action
 jobs:

--- a/.github/workflows/read.yml
+++ b/.github/workflows/read.yml
@@ -51,11 +51,11 @@ on:
       tags:
         description: Add tags to categorize the book. Separate each tag with a comma.
         type: string
-      # Duration is optional and is in ISO 8601 format
-      # Example: PT8H30M0S
-      # (8 hours, 30 minutes, and 0 seconds)
+      # Duration is optional and is in HH:MM format.
+      # Example: 8:30
+      # The example above is 8 hours and 30 minutes.
       duration:
-        description: Duration of the Libby audiobook in ISO 8601 format (PT##H##M##S).
+        description: Duration of the Libby audiobook (HH:MM).
         type: string
 
 # Set up the steps to run the action

--- a/.github/workflows/read.yml
+++ b/.github/workflows/read.yml
@@ -51,11 +51,9 @@ on:
       tags:
         description: Add tags to categorize the book. Separate each tag with a comma.
         type: string
-      # Duration is optional
-      # It must be in ISO 8601 format
-      # Example:
-      # PT8H30M0S
-      # is 8 hours, 30 minutes, and 0 seconds
+      # Duration is optional and is in ISO 8601 format
+      # Example: PT8H30M0S
+      # (8 hours, 30 minutes, and 0 seconds)
       duration:
         description: Duration of the Libby audiobook in ISO 8601 format (PT##H##M##S).
         type: string

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ on:
       tags:
         description: Add tags to categorize the book. Separate each tag with a comma.
         type: string
-      # Duration is optional and is in ISO 8601 format
-      # Example: PT8H30M0S
-      # (8 hours, 30 minutes, and 0 seconds)
+      # Duration is optional and is in HH:MM format.
+      # Example: 8:30
+      # The example above is 8 hours and 30 minutes.
       duration:
-        description: Duration of the Libby audiobook in ISO 8601 format (PT##H##M##S).
+        description: Duration of the Libby audiobook (HH:MM).
         type: string
 
 # Set up the steps to run the action
@@ -346,7 +346,7 @@ To trigger the action, [create a workflow dispatch event](https://docs.github.co
     "notes": "", // Notes about the book. Optional.
     "rating": "", // Rate the book. Optional. You can completely customize the default value and options. Default: `unrated`. Options: `unrated`, `⭐️`, `⭐️⭐️`, `⭐️⭐️⭐️`, `⭐️⭐️⭐️⭐️`, `⭐️⭐️⭐️⭐️⭐️`.
     "tags": "", // Add tags to categorize the book. Separate each tag with a comma.
-    "duration": "", // Duration of the Libby audiobook in ISO 8601 format (PT##H##M##S).
+    "duration": "", // Duration of the Libby audiobook (HH:MM).
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ on:
       tags:
         description: Add tags to categorize the book. Separate each tag with a comma.
         type: string
+      # Duration is optional
+      # It must be in ISO 8601 format
+      # Example:
+      # PT8H30M0S
+      # is 8 hours, 30 minutes, and 0 seconds
+      duration:
+        description: Duration of the Libby audiobook in ISO 8601 format (PT##H##M##S).
+        type: string
 
 # Set up the steps to run the action
 jobs:
@@ -340,6 +348,7 @@ To trigger the action, [create a workflow dispatch event](https://docs.github.co
     "notes": "", // Notes about the book. Optional.
     "rating": "", // Rate the book. Optional. You can completely customize the default value and options. Default: `unrated`. Options: `unrated`, `⭐️`, `⭐️⭐️`, `⭐️⭐️⭐️`, `⭐️⭐️⭐️⭐️`, `⭐️⭐️⭐️⭐️⭐️`.
     "tags": "", // Add tags to categorize the book. Separate each tag with a comma.
+    "duration": "", // Duration of the Libby audiobook in ISO 8601 format (PT##H##M##S).
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -85,11 +85,9 @@ on:
       tags:
         description: Add tags to categorize the book. Separate each tag with a comma.
         type: string
-      # Duration is optional
-      # It must be in ISO 8601 format
-      # Example:
-      # PT8H30M0S
-      # is 8 hours, 30 minutes, and 0 seconds
+      # Duration is optional and is in ISO 8601 format
+      # Example: PT8H30M0S
+      # (8 hours, 30 minutes, and 0 seconds)
       duration:
         description: Duration of the Libby audiobook in ISO 8601 format (PT##H##M##S).
         type: string

--- a/_data/read.json
+++ b/_data/read.json
@@ -516,7 +516,7 @@
       "libby": "4681636"
     },
     "dateAdded": "2025-01-05",
-    "status": "want to read",
+    "status": "started",
     "rating": "unrated",
     "link": "https://share.libbyapp.com/title/4681636",
     "title": "Long Bright River",
@@ -532,6 +532,7 @@
       "Thriller"
     ],
     "format": "audiobook",
-    "duration": "PT13H0M"
+    "duration": "PT13H0M",
+    "dateStarted": "2025-01-05"
   }
 ]

--- a/_data/read.json
+++ b/_data/read.json
@@ -509,5 +509,29 @@
     "language": "en",
     "link": "https://libro.fm/audiobooks/9780593867792",
     "duration": "PT14H34M15S"
+  },
+  {
+    "identifier": "4681636",
+    "identifiers": {
+      "libby": "4681636"
+    },
+    "dateAdded": "2025-01-05",
+    "status": "want to read",
+    "rating": "unrated",
+    "link": "https://share.libbyapp.com/title/4681636",
+    "title": "Long Bright River",
+    "description": "ONE OF BARACK OBAMA’S FAVORITE BOOKS OF THE YEAR, BY THE AUTHOR OF THE THE GOD OF THE WOODS   [Moore’s] careful balance of the hard-bitten with the heartfelt is what elevates Long Bright River from entertaining page-turner to a book that makes you want to call someone you love. - The New York Times Book ReviewThis is police proce...",
+    "authors": [
+      "Liz Moore"
+    ],
+    "publishedDate": "2020-01-07",
+    "thumbnail": "https://img1.od-cdn.com/ImageType-100/1191-1/{CF95195D-2BB7-4471-93EB-B7084481069E}Img100.jpg",
+    "publisher": "Books on Tape",
+    "categories": [
+      "Fiction",
+      "Thriller"
+    ],
+    "format": "audiobook",
+    "duration": "PT13H0M"
   }
 ]

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -617,4 +617,23 @@ describe("index", () => {
       'Invalid `book-status` in payload: "did not finish". Choose from: "want to read", "started", "finished", "abandoned"'
     );
   });
+
+  test("error, bad duration", async () => {
+    const setFailedSpy = jest.spyOn(core, "setFailed");
+    Object.defineProperty(github, "context", {
+      value: {
+        payload: {
+          inputs: {
+            identifier: "9781760983215",
+            "book-status": "finished",
+            duration: "1234",
+          },
+        },
+      },
+    });
+    await read();
+    expect(setFailedSpy).toHaveBeenCalledWith(
+      'Invalid `duration` in payload: 1234. Must be in ISO 8601 format, example: "PT8H30M40S" is 8 hours, 30 minutes, and 40 seconds'
+    );
+  });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -633,7 +633,7 @@ describe("index", () => {
     });
     await read();
     expect(setFailedSpy).toHaveBeenCalledWith(
-      'Invalid `duration` in payload: 1234. Must be in ISO 8601 format, example: "PT8H30M40S" is 8 hours, 30 minutes, and 40 seconds'
+      'Invalid `duration` in payload: 1234. Must be in HH:MM format, example: "08:30" is 8 hours and 30 minutes'
     );
   });
 });

--- a/src/__tests__/validate-payload.test.ts
+++ b/src/__tests__/validate-payload.test.ts
@@ -71,7 +71,7 @@ describe("validatePayload", () => {
     expect(result).toEqual({
       success: false,
       message:
-        'Invalid `duration` in payload: 8H30M40S. Must be in ISO 8601 format, example: "PT8H30M40S" is 8 hours, 30 minutes, and 40 seconds',
+        'Invalid `duration` in payload: 8H30M40S. Must be in HH:MM format, example: "08:30" is 8 hours and 30 minutes',
     });
   });
 
@@ -80,7 +80,7 @@ describe("validatePayload", () => {
       "book-status": "started",
       identifier: "https://share.libbyapp.com/123",
       date: "2023-01-01",
-      duration: "PT8H30M40S",
+      duration: "8:30",
     } as BookPayload;
     const result = validatePayload(payload);
     expect(result).toEqual({ success: true, message: "Valid payload" });

--- a/src/__tests__/validate-payload.test.ts
+++ b/src/__tests__/validate-payload.test.ts
@@ -1,0 +1,88 @@
+import { validatePayload } from "../validate-payload";
+import { BookPayload } from "../index";
+
+describe("validatePayload", () => {
+  it("should return success false and message 'Missing payload' when payload is undefined", () => {
+    const result = validatePayload(undefined as unknown as BookPayload);
+    expect(result).toEqual({ success: false, message: "Missing payload" });
+  });
+
+  it("should return success true and message 'Valid payload' when book-status is 'summary'", () => {
+    const payload = { "book-status": "summary" } as BookPayload;
+    const result = validatePayload(payload);
+    expect(result).toEqual({ success: true, message: "Valid payload" });
+  });
+
+  it("should return success false and message 'Missing `identifier` in payload' when identifier is missing", () => {
+    const payload = { "book-status": "started" } as BookPayload;
+    const result = validatePayload(payload);
+    expect(result).toEqual({
+      success: false,
+      message: "Missing `identifier` in payload",
+    });
+  });
+
+  it("should return success false and message 'Invalid `identifier` in payload' when identifier is invalid", () => {
+    const payload = {
+      "book-status": "started",
+      identifier: "invalid-identifier",
+    } as BookPayload;
+    const result = validatePayload(payload);
+    expect(result).toEqual({
+      success: false,
+      message:
+        "Invalid `identifier` in payload: invalid-identifier. Must be an ISBN or start with one of the following: https://share.libbyapp.com/, https://libro.fm/, https://books.apple.com/",
+    });
+  });
+
+  it("should return success false and message 'Invalid `date` in payload' when date is invalid", () => {
+    const payload = {
+      "book-status": "started",
+      identifier: "https://share.libbyapp.com/123",
+      date: "invalid-date",
+    } as BookPayload;
+    const result = validatePayload(payload);
+    expect(result).toEqual({
+      success: false,
+      message: "Invalid `date` in payload: invalid-date",
+    });
+  });
+
+  it("should return success false and message 'Invalid `book-status` in payload' when book-status is invalid", () => {
+    const payload = {
+      "book-status": "invalid-status",
+      identifier: "https://share.libbyapp.com/123",
+    } as BookPayload;
+    const result = validatePayload(payload);
+    expect(result).toEqual({
+      success: false,
+      message:
+        'Invalid `book-status` in payload: "invalid-status". Choose from: "want to read", "started", "finished", "abandoned"',
+    });
+  });
+
+  it("should return success false and message 'Invalid `duration` in payload' when duration is invalid", () => {
+    const payload = {
+      "book-status": "started",
+      identifier: "https://share.libbyapp.com/123",
+      duration: "8H30M40S",
+    } as BookPayload;
+    const result = validatePayload(payload);
+    expect(result).toEqual({
+      success: false,
+      message:
+        'Invalid `duration` in payload: 8H30M40S. Must be in ISO 8601 format, example: "PT8H30M40S" is 8 hours, 30 minutes, and 40 seconds',
+    });
+  });
+
+  it("should return success true and message 'Valid payload' when payload is valid", () => {
+    const payload = {
+      "book-status": "started",
+      identifier: "https://share.libbyapp.com/123",
+      date: "2023-01-01",
+      duration: "PT8H30M40S",
+    } as BookPayload;
+    const result = validatePayload(payload);
+    expect(result).toEqual({ success: true, message: "Valid payload" });
+  });
+});

--- a/src/__tests__/workflow-libby.test.ts
+++ b/src/__tests__/workflow-libby.test.ts
@@ -289,7 +289,7 @@ describe("workflow", () => {
           inputs: {
             identifier: "https://share.libbyapp.com/title/5004990",
             "book-status": "want to read",
-            duration: "PT8H32M40S",
+            duration: "8:32",
           },
         },
       },
@@ -312,7 +312,7 @@ describe("workflow", () => {
             ],
             "dateAdded": "2022-10-01",
             "description": "WINNER of the NBCC John Leonard Prize, the Kirkus Prize, the Center for Fiction First Novel Prize, the Dylan Thomas Prize, and the VCU Cabell First Novelist AwardOne of Barack Obama’s Favorite Books of 2020 A BEST BOOK OF THE YEAR: NPR, The New York Times Book Review, O Magazine, Vanity Fair, Los Angeles Times, Glamour, Shondaland,...",
-            "duration": "PT8H32M40S",
+            "duration": "PT8H32M",
             "format": "ebook",
             "identifier": "5004990",
             "identifiers": {

--- a/src/__tests__/workflow-libby.test.ts
+++ b/src/__tests__/workflow-libby.test.ts
@@ -274,4 +274,61 @@ describe("workflow", () => {
       ]
     `);
   });
+
+  test("want to read, reader-defined duration", async () => {
+    ogs.mockResolvedValue({
+      result: result_5004990,
+      html: html_5004990,
+    });
+    jest.spyOn(promises, "readFile").mockResolvedValue();
+    jest.useFakeTimers().setSystemTime(new Date("2022-10-01T12:00:00"));
+    const setFailedSpy = jest.spyOn(core, "setFailed");
+    Object.defineProperty(github, "context", {
+      value: {
+        payload: {
+          inputs: {
+            identifier: "https://share.libbyapp.com/title/5004990",
+            "book-status": "want to read",
+            duration: "PT8H32M40S",
+          },
+        },
+      },
+    });
+    await read();
+    expect(setFailedSpy).not.toHaveBeenCalled();
+    expect(returnWriteFile.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        "my-library.json",
+        [
+          {
+            "authors": [
+              "Raven Leilani",
+            ],
+            "categories": [
+              "Fiction",
+              "African American Fiction",
+              "Literature",
+              "Historical Fiction",
+            ],
+            "dateAdded": "2022-10-01",
+            "description": "WINNER of the NBCC John Leonard Prize, the Kirkus Prize, the Center for Fiction First Novel Prize, the Dylan Thomas Prize, and the VCU Cabell First Novelist AwardOne of Barack Obama’s Favorite Books of 2020 A BEST BOOK OF THE YEAR: NPR, The New York Times Book Review, O Magazine, Vanity Fair, Los Angeles Times, Glamour, Shondaland,...",
+            "duration": "PT8H32M40S",
+            "format": "ebook",
+            "identifier": "5004990",
+            "identifiers": {
+              "isbn": "9780374910334",
+              "libby": "5004990",
+            },
+            "image": "book-5004990.png",
+            "link": "https://share.libbyapp.com/title/5004990",
+            "publishedDate": "2020-08-04",
+            "publisher": "Farrar, Straus and Giroux",
+            "status": "want to read",
+            "thumbnail": "https://img2.od-cdn.com/ImageType-100/2390-1/{AC83A465-D32D-46B4-A70E-EFD2F0E2F7F6}Img100.jpg",
+            "title": "Luster",
+          },
+        ],
+      ]
+    `);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type BookPayload = {
   identifier: string;
   rating?: string;
   tags?: string;
+  duration?: string;
 };
 
 export type ActionInputs = {
@@ -44,6 +45,7 @@ export type BookParams = {
   tags?: string[];
   thumbnailWidth?: number;
   setImage: boolean;
+  duration?: string;
 };
 
 export async function read() {
@@ -63,6 +65,7 @@ export async function read() {
       notes,
       rating,
       tags,
+      duration,
     } = payload;
     // Set inputs
     const filename: ActionInputs["filename"] = getInput("filename");
@@ -96,6 +99,7 @@ export async function read() {
       thumbnailWidth,
       setImage,
       ...(tags && { tags: toArray(tags) }),
+      ...(duration && { duration }),
     };
 
     if (bookStatus !== "summary") {

--- a/src/providers/libby.ts
+++ b/src/providers/libby.ts
@@ -56,11 +56,17 @@ export async function getLibby(
       link: inputIdentifier,
       ...parsedResultMetadata,
       ...parsedHtmlMetadata,
-      ...(duration && { duration }),
+      ...(duration && { duration: toIsoFormat(duration) }),
     };
   } catch (error) {
     throw new Error(`Failed to get book from Libby: ${error.result.error}`);
   }
+}
+
+function toIsoFormat(duration: string): string {
+  // convert HH:MM to ISO 8601 duration format
+  const [hours, minutes] = duration.split(":").map(Number);
+  return `PT${hours}H${minutes}M`;
 }
 
 function handleFormat(shareCategory: string): string | undefined {

--- a/src/providers/libby.ts
+++ b/src/providers/libby.ts
@@ -20,6 +20,7 @@ export async function getLibby(
     rating,
     tags,
     setImage,
+    duration,
   } = options;
   try {
     const ogsOptions = {
@@ -55,6 +56,7 @@ export async function getLibby(
       link: inputIdentifier,
       ...parsedResultMetadata,
       ...parsedHtmlMetadata,
+      ...(duration && { duration }),
     };
   } catch (error) {
     throw new Error(`Failed to get book from Libby: ${error.result.error}`);

--- a/src/validate-payload.ts
+++ b/src/validate-payload.ts
@@ -50,6 +50,19 @@ export function validatePayload(payload: BookPayload): {
     };
   }
 
+  // Make sure duration is in ISO 8601 format
+  if (
+    payload["duration"] &&
+    !/^P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+S)?)?$/.test(
+      payload["duration"]
+    )
+  ) {
+    return {
+      success: false,
+      message: `Invalid \`duration\` in payload: ${payload["duration"]}. Must be in ISO 8601 format, example: "PT8H30M40S" is 8 hours, 30 minutes, and 40 seconds`,
+    };
+  }
+
   return { success: true, message: "Valid payload" };
 }
 

--- a/src/validate-payload.ts
+++ b/src/validate-payload.ts
@@ -51,7 +51,7 @@ export function validatePayload(payload: BookPayload): {
   }
 
   // Make sure duration is in HH:MM format
-  if (payload["duration"] && !/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(payload["duration"])) {
+  if (payload["duration"] && !/^\d{1,2}:\d{2}$/.test(payload["duration"])) {
     return {
       success: false,
       message: `Invalid \`duration\` in payload: ${payload["duration"]}. Must be in HH:MM format, example: "08:30" is 8 hours and 30 minutes`,

--- a/src/validate-payload.ts
+++ b/src/validate-payload.ts
@@ -50,16 +50,11 @@ export function validatePayload(payload: BookPayload): {
     };
   }
 
-  // Make sure duration is in ISO 8601 format
-  if (
-    payload["duration"] &&
-    !/^P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+S)?)?$/.test(
-      payload["duration"]
-    )
-  ) {
+  // Make sure duration is in HH:MM format
+  if (payload["duration"] && !/^\d{1,2}:\d{2}$/.test(payload["duration"])) {
     return {
       success: false,
-      message: `Invalid \`duration\` in payload: ${payload["duration"]}. Must be in ISO 8601 format, example: "PT8H30M40S" is 8 hours, 30 minutes, and 40 seconds`,
+      message: `Invalid \`duration\` in payload: ${payload["duration"]}. Must be in HH:MM format, example: "08:30" is 8 hours and 30 minutes`,
     };
   }
 

--- a/src/validate-payload.ts
+++ b/src/validate-payload.ts
@@ -51,7 +51,7 @@ export function validatePayload(payload: BookPayload): {
   }
 
   // Make sure duration is in HH:MM format
-  if (payload["duration"] && !/^\d{1,2}:\d{2}$/.test(payload["duration"])) {
+  if (payload["duration"] && !/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(payload["duration"])) {
     return {
       success: false,
       message: `Invalid \`duration\` in payload: ${payload["duration"]}. Must be in HH:MM format, example: "08:30" is 8 hours and 30 minutes`,


### PR DESCRIPTION
While we can get the duration of audiobooks from Libro.fm and Apple Books, it's difficult to scrape it from Libby. This PR introduces a new book payload parameter, `duration`, to allow the reader to pass through the duration of the Libby book if they chose.

Fixes #186 